### PR TITLE
Fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ $ npm i -g mc-build
 
 ### documentation
 
-[https://mcbuild.dev/docs](docs)
+[https://mcbuild.dev/docs](https://mcbuild.dev/docs)
 
 ### I as well as the mc-build project am not affiliated with Mojang in any way.


### PR DESCRIPTION
When you click on the docs link in the README.md it takes you to [https://github.com/mc-build/mc-build/blob/master/docs](https://github.com/mc-build/mc-build/blob/master/docs) instead of [https://mcbuild.dev/docs](https://mcbuild.dev/docs) 
Feel free to deny this PR and fix it up.