### PR TITLE
Fix wrong naming inside check_for_lang_updates.js

### DIFF
--- a/lib/core/check_for_lang_updates.js
+++ b/lib/core/check_for_lang_updates.js
@@ -317,7 +317,7 @@
 				) {
 					logger.log(
 						'using cache for ' +
-							item.type +
+							task.type +
 							" '" +
 							task.item.name +
 							"'"
@@ -326,7 +326,7 @@
 					version = version || 'stable'
 					logger.info(
 						`downloading ${
-							item.type
+							task.type
 						} ${name} branch ${version} from '${`https://github.com/${task.item.remote.owner}/${name}/archive/${task.sha}.zip'`}`
 					)
 					removeDir(TARGET_DIR)


### PR DESCRIPTION
Some strings returned undefined, because item.type was used, but it should have been task.type inside check_for_lang_updates.js